### PR TITLE
Issue #1 -- 'Solved made Plugin-specific namespace for models.' --Res…

### DIFF
--- a/app/thunder/samples/model-sample.php
+++ b/app/thunder/samples/model-sample.php
@@ -2,6 +2,8 @@
 
 namespace {NAMESPACE};
 
+use \Model\Model; 
+
 defined('ROOT') or die("Direct script access denied");
 
 /**


### PR DESCRIPTION
Successfully, Solved the Issue of pugin specifi model namespace collision issue.
further more, 
       Plugin can independently choose from various database using add_filter('before_db_connect', $vars).. Vice versa.
       and Plugin will have now an Custom Namespace corresponding to model class . 
       Adding 'use \Model\Model ;'  -- Importing an Model class (Main Model).
       
       Solved and closed.